### PR TITLE
[BUGFIX] define alternative as text in tx_mkcontentai_domain_model_al…

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -2,7 +2,7 @@ CREATE TABLE tx_mkcontentai_domain_model_alt_text_logs
 (
     uid int(11) NOT NULL auto_increment,
     pid int(11) DEFAULT '0' NOT NULL,
-    alternative varchar(255) NOT NULL DEFAULT '',
+    alternative text,
     table_name varchar(50) NOT NULL DEFAULT '',
     sys_file_metadata int(11) unsigned DEFAULT '0',
     PRIMARY KEY (uid)


### PR DESCRIPTION
…t_text_logs

relates: #10



![image](https://github.com/user-attachments/assets/1819b7fa-aa97-44ce-8fd7-f0b7b6864195)
