### PR TITLE
[BUGFIX] Don't render file list actions on insufficient permissions

### DIFF
--- a/Classes/Backend/EventListener/FileListActionsEventListener.php
+++ b/Classes/Backend/EventListener/FileListActionsEventListener.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace DMK\MkContentAi\Backend\EventListener;
 
 use DMK\MkContentAi\ContextMenu\ContentAiItemProvider;
+use DMK\MkContentAi\Utility\PermissionsUtility;
 use Psr\Http\Message\UriInterface;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -29,11 +30,13 @@ use TYPO3\CMS\Filelist\Event\ProcessFileListActionsEvent;
 
 final class FileListActionsEventListener
 {
-    protected ContentAiItemProvider $contentAiItemProvider;
+    private ContentAiItemProvider $contentAiItemProvider;
+    private PermissionsUtility $permissionsUtility;
     private Typo3Version $typo3Version;
 
-    public function __construct(Typo3Version $typo3Version)
+    public function __construct(PermissionsUtility $permissionsUtility, Typo3Version $typo3Version)
     {
+        $this->permissionsUtility = $permissionsUtility;
         $this->typo3Version = $typo3Version;
 
         if (11 === $this->typo3Version->getMajorVersion()) {
@@ -47,6 +50,10 @@ final class FileListActionsEventListener
 
     public function handleEvent(ProcessFileListActionsEvent $event): void
     {
+        if (!$this->permissionsUtility->userHasAccessToImageGenerationPromptButton()) {
+            return;
+        }
+
         $resourceIdentifier = $this->getFileIdentifier($event->getResource());
 
         if ('' === $resourceIdentifier) {


### PR DESCRIPTION
## About this PR

This PR addresses a permission issue for file list actions. If a backend user (non-admin) has insufficient permissions to perform image alt text generation, the appropriate actions should not be rendered. The proposed implementation is in line with other implementations like `DMK\MkContentAi\Backend\EventListener\CustomFileControlsEventListener::handleEvent` and `DMK\MkContentAi\Backend\EventListener\ModifyFilelistButtonBarEventListener::handleEvent`.

## Before

![image](https://github.com/user-attachments/assets/b0c6412e-3e59-4169-8469-fe12eceb7e7e)

## After

![image](https://github.com/user-attachments/assets/9bc7edb1-7f3c-4d12-8012-84287bf593a0)
