### PR TITLE
Enhancment: Only show buttons and context menu entries if api key is set

### DIFF
--- a/Classes/Backend/EventListener/CustomFileControlsEventListener.php
+++ b/Classes/Backend/EventListener/CustomFileControlsEventListener.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace DMK\MkContentAi\Backend\EventListener;
 
 use DMK\MkContentAi\Utility\PermissionsUtility;
+use DMK\MkContentAi\Utility\SettingsUtility;
 use TYPO3\CMS\Backend\Form\Event\CustomFileControlsEvent;
 use TYPO3\CMS\Backend\Form\NodeFactory;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -38,11 +39,14 @@ final class CustomFileControlsEventListener
 
     private PermissionsUtility $permissionsUtility;
 
-    public function __construct(PermissionsUtility $permissionsUtility)
+    private SettingsUtility $settingsUtility;
+
+    public function __construct(PermissionsUtility $permissionsUtility, SettingsUtility $settingsUtility)
     {
         $this->nodeFactory = GeneralUtility::makeInstance(NodeFactory::class);
         $this->iconFactory = GeneralUtility::makeInstance(IconFactory::class);
         $this->permissionsUtility = $permissionsUtility;
+        $this->settingsUtility = $settingsUtility;
     }
 
     public function handleEvent(CustomFileControlsEvent $event): void
@@ -50,6 +54,10 @@ final class CustomFileControlsEventListener
         if (!$this->permissionsUtility->userHasAccessToImageGenerationPromptButton()) {
             return;
         }
+        if (!$this->settingsUtility->isApiKeySetForImageGeneration()) {
+            return;
+        }
+
         $iconSize = 'small';
         $translatedMessage = LocalizationUtility::translate('labelAiGenerateText', 'mkcontentai') ?? '';
         $item = ' <div class="form-control-wrap"><button type="button" class="btn btn-primary t3js-prompt" id="prompt">';

--- a/Classes/Backend/EventListener/ModifyFilelistButtonBarEventListener.php
+++ b/Classes/Backend/EventListener/ModifyFilelistButtonBarEventListener.php
@@ -16,6 +16,7 @@
 namespace DMK\MkContentAi\Backend\EventListener;
 
 use DMK\MkContentAi\Utility\PermissionsUtility;
+use DMK\MkContentAi\Utility\SettingsUtility;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Template\Components\ButtonBar;
 use TYPO3\CMS\Backend\Template\Components\ModifyButtonBarEvent;
@@ -33,15 +34,21 @@ class ModifyFilelistButtonBarEventListener
 
     private PermissionsUtility $permissionsUtility;
 
-    public function __construct(PermissionsUtility $permissionsUtility)
+    private SettingsUtility $settingsUtility;
+
+    public function __construct(PermissionsUtility $permissionsUtility, SettingsUtility $settingsUtility)
     {
         $this->iconFactory = GeneralUtility::makeInstance(IconFactory::class);
         $this->permissionsUtility = $permissionsUtility;
+        $this->settingsUtility = $settingsUtility;
     }
 
     public function handleEvent(ModifyButtonBarEvent $event): void
     {
         if (!$this->permissionsUtility->userHasAccessToImageGenerationPromptButton()) {
+            return;
+        }
+        if (!$this->settingsUtility->isApiKeySetForImageGeneration()) {
             return;
         }
 

--- a/Classes/Backend/Form/Element/InputTextWithAiAltTextSupportElement.php
+++ b/Classes/Backend/Form/Element/InputTextWithAiAltTextSupportElement.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace DMK\MkContentAi\Backend\Form\Element;
 
+use DMK\MkContentAi\Utility\SettingsUtility;
 use TYPO3\CMS\Backend\Form\Element\InputTextElement;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
@@ -34,6 +35,10 @@ class InputTextWithAiAltTextSupportElement extends InputTextElement
         $resultArray = parent::render();
 
         if ('sys_file_reference' !== $this->data['tableName'] || 'alternative' !== $this->data['fieldName']) {
+            return $resultArray;
+        }
+
+        if (!GeneralUtility::makeInstance(SettingsUtility::class)->isApiKeySetForAltTextAi()) {
             return $resultArray;
         }
 

--- a/Classes/ContextMenu/ContentAiItemProvider.php
+++ b/Classes/ContextMenu/ContentAiItemProvider.php
@@ -32,6 +32,7 @@ use DMK\MkContentAi\Controller\AiImageController;
 use DMK\MkContentAi\Controller\SettingsController;
 use DMK\MkContentAi\Http\Client\OpenAiClient;
 use DMK\MkContentAi\Http\Client\StabilityAiClient;
+use DMK\MkContentAi\Utility\SettingsUtility;
 use Psr\Http\Message\UriInterface;
 use TYPO3\CMS\Backend\ContextMenu\ItemProviders\AbstractProvider;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -129,13 +130,13 @@ class ContentAiItemProvider extends AbstractProvider
         $canRender = false;
 
         if (
-            (('fileUpscale' === $itemName || 'fileExtend' === $itemName || 'filePrepareImageToVideo' === $itemName) && true === $this->checkAllowedOperationsByClient($itemName, $imageAiEngine))
-            || 'fileAlt' === $itemName
+            (('fileUpscale' === $itemName || 'fileExtend' === $itemName || 'filePrepareImageToVideo' === $itemName) && true === $this->checkAllowedOperationsByClient($itemName, $imageAiEngine) && GeneralUtility::makeInstance(SettingsUtility::class)->isApiKeySetForImageGeneration())
+            || 'fileAlt' === $itemName && GeneralUtility::makeInstance(SettingsUtility::class)->isApiKeySetForAltTextAi()
         ) {
             return $this->isImage();
         }
 
-        if ('folderAltTexts' === $itemName) {
+        if ('folderAltTexts' === $itemName &&  GeneralUtility::makeInstance(SettingsUtility::class)->isApiKeySetForAltTextAi()) {
             return $this->isFolder();
         }
 

--- a/Classes/ContextMenu/ContentAiPageProvider.php
+++ b/Classes/ContextMenu/ContentAiPageProvider.php
@@ -17,6 +17,7 @@ namespace DMK\MkContentAi\ContextMenu;
 
 use DMK\MkContentAi\Domain\Model\TtContent;
 use DMK\MkContentAi\Domain\Repository\TtContentRepository;
+use DMK\MkContentAi\Utility\SettingsUtility;
 use Psr\Http\Message\UriInterface;
 use TYPO3\CMS\Backend\ContextMenu\ItemProviders\AbstractProvider;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -99,6 +100,10 @@ class ContentAiPageProvider extends AbstractProvider
     {
         $canRender = false;
         $availableActions = ['translateContentEasy', 'translateContentPlain'];
+
+        if (!GeneralUtility::makeInstance(SettingsUtility::class)->isApiKeySetForSummAi()) {
+            return false;
+        }
 
         if (in_array($itemName, $availableActions)) {
             $canRender = $this->isPageContent() && $this->isValidTypeOfRecord((int) $this->identifier);

--- a/Classes/Utility/SettingsUtility.php
+++ b/Classes/Utility/SettingsUtility.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace DMK\MkContentAi\Utility;
+
+use DMK\MkContentAi\Controller\AiImageController;
+use DMK\MkContentAi\Controller\SettingsController;
+use DMK\MkContentAi\Http\Client\AltTextClient;
+use DMK\MkContentAi\Http\Client\SummAiClient;
+use TYPO3\CMS\Core\Registry;
+
+class SettingsUtility
+{
+    private Registry $registry;
+
+    public function injectRegistry(Registry $registry): void
+    {
+        $this->registry = $registry;
+    }
+
+    public function isApiKeySetForImageGeneration(): bool
+    {
+        $imageAiEngine = SettingsController::getImageAiEngine();
+        return $this->isApiKeySetForClient(AiImageController::GENERATOR_ENGINE[$imageAiEngine]);
+    }
+
+    public function isApiKeySetForAltTextAi(): bool
+    {
+        return $this->isApiKeySetForClient(AltTextClient::class);
+    }
+
+    public function isApiKeySetForSummAi(): bool
+    {
+        return $this->isApiKeySetForClient(SummAiClient::class);
+    }
+
+    private function isApiKeySetForClient(string $client): bool
+    {
+        return !is_null($this->registry->get($client, 'apiKey'));
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -57,6 +57,13 @@ services:
                   $context: '@TYPO3\CMS\Core\Context\Context'
         public: true
 
+    DMK\MkContentAi\Utility\SettingsUtility:
+        calls:
+            - method: 'injectRegistry'
+              arguments:
+                  $registry: '@TYPO3\CMS\Core\Registry'
+        public: true
+
     DMK\MkContentAi\Service\SiteLanguageService:
         public: true
 


### PR DESCRIPTION
With the changes the buttons and context menu entries are only displayed, if the corresponding service is setup with an API key. As proposed in #21 